### PR TITLE
Materialized changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+.stack-work/

--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@ you're planning, this might well be suitable and much simpler.
 
 ```sh
 brew install zookeeper
-export CPATH=$(brew --prefix zookeeper)/include/zookeeper:$CPATH
+export CPATH=$(brew --prefix zookeeper)/include:$CPATH
 ```
 
 ## Installing dependencies on debian / ubuntu
 
 ```sh
 sudo apt-get install libzookeeper-mt-dev
-export CPATH=/usr/include/zookeeper:$CPATH
 ```
 
 ## Building Stronghold

--- a/cide.yml
+++ b/cide.yml
@@ -1,0 +1,23 @@
+---
+from: ubuntu:12.04
+as_root:
+  add:
+    /etc/apt/sources.list.d/fpco.key: https://s3.amazonaws.com/download.fpcomplete.com/ubuntu/fpco.key
+  env:
+    DEBIAN_FRONTEND: noninteractive
+    # Workaround for: https://github.com/commercialhaskell/stack/issues/793
+    LC_ALL: C.UTF-8
+  run:
+    - apt-key add /etc/apt/sources.list.d/fpco.key
+    - echo 'deb http://download.fpcomplete.com/ubuntu/precise stable main' > /etc/apt/sources.list.d/fpco.list
+    - >
+      apt-get update -qq && apt-get install -qy
+      libzookeeper-mt-dev
+      stack
+before:
+  add:
+    - stronghold.cabal
+    - script/ci-before
+    - stack.yaml
+  run: script/ci-before
+run: script/ci

--- a/script/build
+++ b/script/build
@@ -6,15 +6,9 @@ if [ -z "$TARGET" ]; then
   exit 1
 fi
 
-# For executable links
-BINS="$TARGET/.packager/bin"
+mkdir -p "$TARGET"
+stack install stronghold:stronghold --local-bin-path "$TARGET"
 
-# Build and copy executables
-mkdir -p "$BINS"
-
-CPATH=/usr/include/zookeeper stack install stronghold:stronghold \
-        --local-bin-path "$TARGET"
-
-pushd "$BINS"
-ln -s "../../stronghold" .
-popd
+# Packager symlinks
+mkdir -p "$TARGET/.packager/bin"
+ln -s ../../stronghold "$TARGET/.packager/bin/stronghold"

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+cd "$(dirname "$0")/.."
+
+stack test --fast

--- a/script/ci-before
+++ b/script/ci-before
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+cd "$(dirname "$0")/.."
+
+# Build dependencies
+stack setup
+stack build --only-snapshot
+# Install git dependencies
+stack build zookeeper

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ packages:
     commit: e724636886e3590624f79e1267bfb4d8eab96f86
 resolver: lts-3.20
 nix:
+  enable: false
   packages:
     - gcc
     - git

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,5 +3,12 @@ packages:
 - .
 - location:
     git: https://github.com/motus/haskell-zookeeper-client.git
-    commit: 2fe678759e6cd549b830460760d00eca94949879
-resolver: lts-2.7
+    commit: e724636886e3590624f79e1267bfb4d8eab96f86
+resolver: lts-3.20
+nix:
+  packages:
+    - gcc
+    - git
+    - pkgconfig
+    - zlib
+    - zookeeper_mt

--- a/stronghold.cabal
+++ b/stronghold.cabal
@@ -1,9 +1,10 @@
 name:                stronghold
 version:             0.1
 build-type:          Simple
-cabal-version:       >=1.8
+cabal-version:       >=1.10
 
 executable stronghold
+  default-language:    Haskell2010
   ghc-options:         -threaded -rtsopts
   hs-source-dirs:      src
   main-is:             stronghold.hs
@@ -13,6 +14,7 @@ executable stronghold
                        hashable, time, stm, mtl, async, sqlite-simple
 
 executable wipe
+  default-language:    Haskell2010
   ghc-options:         -threaded
   hs-source-dirs:      src
   main-is:             wipe.hs

--- a/stronghold.cabal
+++ b/stronghold.cabal
@@ -11,7 +11,8 @@ executable stronghold
   build-depends:       base >=4.6.0, operational, bytestring, text, aeson,
                        snap-server, snap-core, cereal, zookeeper, cryptohash,
                        base16-bytestring, transformers, unordered-containers,
-                       hashable, time, stm, mtl, async, sqlite-simple
+                       hashable, time, stm, mtl, async, sqlite-simple,
+                       case-insensitive
 
 executable wipe
   default-language:    Haskell2010


### PR DESCRIPTION
This changes the materialized view to return an ETag header which contains the checksum of the body.

Initially the plan was to return the last "Commit ID" that changed the materialized view but that means traversing the history back to find the change, which means an unbounded N requests to zookeeper.

Since we're only interested in finding if the body has changed, making a checksum seems good enough to me.

Most of the changes here are cleanup. I also added cide packaging while at it.

/cc @Nicowcow @mdpye 