### PR TITLE
Mark external package as extra-dep

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
 - location:
     git: https://github.com/motus/haskell-zookeeper-client.git
     commit: e724636886e3590624f79e1267bfb4d8eab96f86
+  extra-dep: true
 resolver: lts-3.20
 nix:
   enable: false


### PR DESCRIPTION
I don't fully understand why I needed to do this. But I was getting this build error:

```
$ stack build

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for stronghold-0.1:
    zookeeper must match -any, but the stack configuration has no specified version
needed since stronghold is a build target.

Some potential ways to resolve this:

  * Set 'allow-newer: true' to ignore all version constraints and build anyway.

  * You may also want to try using the 'stack solver' command.

Plan construction failed.
```

Which led me to this recent stack issue: https://github.com/commercialhaskell/stack/issues/3728
  